### PR TITLE
Improve code style

### DIFF
--- a/lib/cmd/denormalize.ex
+++ b/lib/cmd/denormalize.ex
@@ -7,20 +7,22 @@ defmodule Cmd.Denormalize do
 
   @doc "Takes <cell> paramater from Cmd.main to perform action"
   def run(cspec) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply cspec, "Denormalizing", &(normalize(&1))
   end
 
   defp normalize(cell) do
-		location = cell.location
-		url = Path.join location, "/sys/firmware/current"
+    location = cell.location
+    url = Path.join location, "/sys/firmware/current"
     IO.write "#{cell.name} -> "
-		resp = HTTPotion.put(url, "{\"status\":\"provisional\"}", ["Content-Type": "application/json"])
-		case resp.status_code do
-			200 ->  IO.write "ok\n"
-      400 ->  IO.write "already provisional\n"
-			x ->    IO.write "DENORMALIZATION FAILED (ERROR #{x})\n"
-		end
-	end
-
+    resp = HTTPotion.put(url, ~s({"status": "provisional"}), ["Content-Type": "application/json"])
+    case resp.status_code do
+      200 ->
+        IO.write "ok\n"
+      400 ->
+        IO.write "already provisional\n"
+      x ->
+        IO.write "DENORMALIZATION FAILED (ERROR #{x})\n"
+    end
+  end
 end

--- a/lib/cmd/discover.ex
+++ b/lib/cmd/discover.ex
@@ -6,16 +6,16 @@ defmodule Cmd.Discover do
 
   @doc "Takes paramater(s) from Cmd.main to perform action"
   def run(spec, _opts \\ %{}) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply spec, "NAME\tSERIAL#\t\tTYPE\tVERSION -",
       &(IO.write fsr(&1)<>"\n")
   end
 
   defp fsr(c) do
-		case Jrtp.get_services(c) do
-			{:error, x} ->
-				".#{c.name}\tError #{x} from #{inspect c}"
-			{:ok, svcs} ->
+    case Jrtp.get_services(c) do
+      {:error, x} ->
+        ".#{c.name}\tError #{x} from #{inspect c}"
+      {:ok, svcs} ->
         case svcs.root.description do
           description when is_bitstring(description) -> # v2
             sf = svcs.firmware
@@ -41,7 +41,6 @@ defmodule Cmd.Discover do
           _fw_status ->
             "#{c.name}\t#{sn}\t#{model}\t#{fv} (#{fs})"
         end
-		end
+    end
   end
-
 end

--- a/lib/cmd/inspect.ex
+++ b/lib/cmd/inspect.ex
@@ -24,18 +24,19 @@ defmodule Cmd.Inspect do
   end
 
   defp get_services_doc(cell, path) do
-		location = cell.location
-		url = case path do
+    location = cell.location
+    url = case path do
       nil -> location
       p -> location<>p
     end
     IO.write "from #{url} -> "
-		resp = HTTPotion.get(url)
-		case resp.status_code do
-			200 ->
+    resp = HTTPotion.get(url)
+    case resp.status_code do
+      200 ->
         IO.write "ok\n"
         IO.write "#{resp.body}\n\n"
-			x ->    IO.write "ERROR\n"
-		end
+      _ ->
+        IO.write "ERROR\n"
+    end
   end
 end

--- a/lib/cmd/ip.ex
+++ b/lib/cmd/ip.ex
@@ -2,22 +2,25 @@ defmodule Cmd.Ip do
   @moduledoc "Not yet implemented"
 
   def run(cspec, ip, mask, router) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply cspec, "Setting", &(setip(&1, ip, mask, router))
   end
 
   defp setip(cell, ip, mask, router) do
-		url = Path.join cell.location, "/sys/ip/static"
+    url = Path.join cell.location, "/sys/ip/static"
     IO.write "#{cell.name} -> #{params(ip, mask, router)}"
-		resp = HTTPotion.put(url, params(ip, mask, router), ["Content-Type": "application/json"])
-		case resp.status_code do
-			200 ->  IO.write "ok\n"
-      400 ->  IO.write "ERROR\n"
-			x ->    IO.write "FAILED (ERROR #{x})\n"
-		end
-	end
+    resp = HTTPotion.put(url, params(ip, mask, router), ["Content-Type": "application/json"])
+    case resp.status_code do
+      200 ->
+        IO.write "ok\n"
+      400 ->
+        IO.write "ERROR\n"
+      x ->
+        IO.write "FAILED (ERROR #{x})\n"
+    end
+  end
 
   defp params(ip, mask, router) do
-    "{\"ip\":\"#{ip}\", \"mask\":\"#{mask}\", \"router\":\"#{router}\"}"
+    ~s({"ip": "#{ip}", "mask": "#{mask}", "router": "#{router}"})
   end
 end

--- a/lib/cmd/normalize.ex
+++ b/lib/cmd/normalize.ex
@@ -8,20 +8,22 @@ defmodule Cmd.Normalize do
 
   @doc "Takes paramater(s) from Cmd.main to perform action"
   def run(cspec) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply cspec, "Normalizing", &(normalize(&1))
   end
 
   defp normalize(cell) do
-		location = cell.location
-		url = Path.join location, "/sys/firmware/current"
+    location = cell.location
+    url = Path.join location, "/sys/firmware/current"
     IO.write "#{cell.name} -> "
-		resp = HTTPotion.put(url, "{\"status\":\"normal\"}", ["Content-Type": "application/json"])
-		case resp.status_code do
-			200 ->  IO.write "ok\n"
-      400 ->  IO.write "already normal\n"
-			x ->    IO.write "NORMALIZATION FAILED (ERROR #{x})\n"
-		end
-	end
-
+    resp = HTTPotion.put(url, ~s({"status": "normal"}), ["Content-Type": "application/json"])
+    case resp.status_code do
+      200 ->
+        IO.write "ok\n"
+      400 ->
+        IO.write "already normal\n"
+      x ->
+        IO.write "NORMALIZATION FAILED (ERROR #{x})\n"
+    end
+  end
 end

--- a/lib/cmd/provision.ex
+++ b/lib/cmd/provision.ex
@@ -1,50 +1,52 @@
 defmodule Cmd.Provision do
 
-	@moduledoc """
-	Provisions  a  box for  use,  assuming  the  device  is running  either  generic
-	firmware or firmware with an "open" update policy.
+  @moduledoc """
+  Provisions  a  box for  use,  assuming  the  device  is running  either  generic
+  firmware or firmware with an "open" update policy.
 
-	The app_id is the application ID to install on the box.  A provisioning
-	configuration file <app_id>.exs must exist in ~/.cell/provision.
-	"""
+  The app_id is the application ID to install on the box.  A provisioning
+  configuration file <app_id>.exs must exist in ~/.cell/provision.
+  """
 
   @name         "lock"
   @lock_mime    "application/x-device-lock"
   @lock_path    "sys/firmware"
 
   @lock_timeout 15000
-	@provision_dir "~/.cell/provision/"
+  @provision_dir "~/.cell/provision/"
 
-	@doc "Takes paramater(s) from Cmd.main to perform action"
+  @doc "Takes paramater(s) from Cmd.main to perform action"
   def run(cspec, app_id) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply cspec, "Provisioning as '#{app_id}'", &(provision(&1, app_id))
   end
 
   defp provision(cell, app_id) do
     {:ok, services} = Jrtp.get_services(cell)
-		{_, config} = Code.eval_file("#{app_id}.exs", @provision_dir)
+    {_, config} = Code.eval_file("#{app_id}.exs", @provision_dir)
     serial_number = services.root.serial_number
 
     # decide if activation/locking is required.  If so, call the custom
     # lock function defined in the configuration, passing the serial#
-	  case config[:activate] do
-			f when is_function(f) ->
-				lock_blob = f.(serial_number)
+    case config[:activate] do
+      f when is_function(f) ->
+        lock_blob = f.(serial_number)
         lock_cell(cell, lock_blob)
       _ -> nil
     end
 
-	end
-
-  defp lock_cell(cell, lock_blob) do
-		url = Path.join(cell.location, @lock_path)
-		resp = HTTPotion.put(url, lock_blob, ["Content-Type": @lock_mime], timeout: @lock_timeout)
-		case resp.status_code do
-			201 ->  IO.write "ok\n"
-      204 ->  IO.write "ok\n"
-			x ->    IO.write "LOCK FAILED (ERROR #{x})\n"
-		end
   end
 
+  defp lock_cell(cell, lock_blob) do
+    url = Path.join(cell.location, @lock_path)
+    resp = HTTPotion.put(url, lock_blob, ["Content-Type": @lock_mime], timeout: @lock_timeout)
+    case resp.status_code do
+      201 ->
+        IO.write "ok\n"
+      204 ->
+        IO.write "ok\n"
+      x ->
+        IO.write "LOCK FAILED (ERROR #{x})\n"
+    end
+  end
 end

--- a/lib/cmd/push.ex
+++ b/lib/cmd/push.ex
@@ -5,20 +5,21 @@ defmodule Cmd.Push do
 
   @doc "Takes paramater(s) from Cmd.main to perform action"
   def run(wspec, cspec) do
-		HTTPotion.start
+    HTTPotion.start
     ware = File.read! wspec
     Finder.apply cspec, "Pushing ''#{wspec}' to", &(push_to_cell(&1, ware))
   end
 
   defp push_to_cell(cell, ware) do
-		location = cell.location
-		url = location<>"/sys/firmware/current"
+    location = cell.location
+    url = location <> "/sys/firmware/current"
     IO.write "cell: #{location} -> "
-		resp = HTTPotion.put(url, body: ware, headers: ["Content-Type": "application/x-firmware"], timeout: 120000)
-		case resp.status_code do
-			201 ->  IO.write "ok\n"
-			x ->    IO.write "UPDATE FAILED (ERROR #{x})\n"
-		end
+    resp = HTTPotion.put(url, body: ware, headers: ["Content-Type": "application/x-firmware"], timeout: 120000)
+    case resp.status_code do
+      201 ->
+        IO.write "ok\n"
+      x ->
+        IO.write "UPDATE FAILED (ERROR #{x})\n"
+    end
   end
-
 end

--- a/lib/cmd/reboot.ex
+++ b/lib/cmd/reboot.ex
@@ -8,28 +8,30 @@ defmodule Cmd.Reboot do
   end
 
   defp enable_reboot(cell) do
-		location = cell.location
-		url = location<>"sys/firmware/reboot"
+    location = cell.location
+    url = location <> "sys/firmware/reboot"
     IO.write "reboot enable: #{location} -> "
-		resp = HTTPotion.put(url, "{\"enable_reboot\": \"true\"}", ["Content-Type": "application/json"])
-		case resp.status_code do
-			200 ->
+    resp = HTTPotion.put(url, ~s({"enable_reboot": "true"}), ["Content-Type": "application/json"])
+    case resp.status_code do
+      200 ->
         IO.write "enabled\n"
         :timer.sleep(250)
         execute_reboot(cell)
-			x ->    IO.write "ERROR\n"
-		end
+      _ ->
+        IO.write "ERROR\n"
+    end
   end
 
   defp execute_reboot(cell) do
-		location = cell.location
-		url = location<>"sys/firmware/reboot"
+    location = cell.location
+    url = location <> "sys/firmware/reboot"
     IO.write "rebooting:"
-		resp = HTTPotion.put(url, "{\"execute_reboot\": \"true\"}", ["Content-Type": "application/json"])
-		case resp.status_code do
-			200 ->
+    resp = HTTPotion.put(url, ~s({"execute_reboot": "true"}), ["Content-Type": "application/json"])
+    case resp.status_code do
+      200 ->
         IO.write "ok\n"
-			x ->    IO.write "ERROR\n"
-		end
+      _ ->
+        IO.write "ERROR\n"
+    end
   end
 end

--- a/lib/cmd/test.ex
+++ b/lib/cmd/test.ex
@@ -2,12 +2,11 @@ defmodule Cmd.Test do
   @moduledoc "Not yet implemented"
 
   def run(cspec) do
-		HTTPotion.start
+    HTTPotion.start
     Finder.apply cspec, "Testing", &(test(&1))
   end
 
   defp test(cell) do
     IO.write "Testing cell: #{cell.location}\n"
   end
-
 end

--- a/lib/cmd/watch.ex
+++ b/lib/cmd/watch.ex
@@ -1,22 +1,22 @@
 defmodule Cmd.Watch do
-	@moduledoc """
-	Watches the Logging UDP stream of all cells or the specified cell. The output
-	is prepended by the last octet of the IP address then the logging message.
+  @moduledoc """
+  Watches the Logging UDP stream of all cells or the specified cell. The output
+  is prepended by the last octet of the IP address then the logging message.
 
-	UDP address: 224.0.0.224
-	Port: 9999
-	"""
+  UDP address: 224.0.0.224
+  Port: 9999
+  """
 
-	@mcast_log_group {224,0,0,224}
-	@mcast_log_port  9999
+  @mcast_log_group {224,0,0,224}
+  @mcast_log_port  9999
 
-	@doc "Starts the watch on all cells"
+  @doc "Starts the watch on all cells"
   def run do
     {:ok, socket} = setup_socket
     watch_mcast(socket)
   end
 
-	@doc "Starts the watch on the specified cells"
+  @doc "Starts the watch on the specified cells"
   def run(ip_addr) do
     {:ok, socket} = setup_socket
     watch_mcast(socket, %{ip: ip_addr})
@@ -36,13 +36,12 @@ defmodule Cmd.Watch do
       [_, ip] = String.split(opts[:ip], ".")
       String.to_integer(ip)
     end
-  	receive do
-  		{:udp, socket, {_,_,_,n}, _port, msg} ->
+    receive do
+      {:udp, socket, {_,_,_,n}, _port, msg} ->
           if ip == nil or n == ip do
             IO.write ".#{n}\t#{msg}"
-  	    watch_mcast(socket, opts)
+            watch_mcast(socket, opts)
           end
-  	end
+    end
   end
-
 end

--- a/lib/finder.ex
+++ b/lib/finder.ex
@@ -9,29 +9,29 @@ defmodule Finder do
   @default_service_path "jrtp"
 
   def apply(cspec, title, func) do
-	  if :erlang.is_binary(cspec) and String.length(cspec) > 5 do
-			cells = make_static_cell(cspec)
-	  else
-	    cells = discovered(cspec)
-		end
+    if :erlang.is_binary(cspec) and String.length(cspec) > 5 do
+      cells = make_static_cell(cspec)
+    else
+      cells = discovered(cspec)
+    end
     case Enum.count(cells) do
       0 -> nil
-			n ->
+      n ->
         IO.write "#{title} #{n} cell(s)\n"
-    		for {_, cell} <- cells do
+        for {_, cell} <- cells do
           func.(cell)
         end
     end
   end
 
-	# return a single cell with the specified location, because the user
-	# asked for a specific cell in ip:port form.
-	defp make_static_cell(cspec) do
-		%{ "remote": %{ location: "http://#{cspec}/#{services_loc}", name: cspec }}
-	end
+  # return a single cell with the specified location, because the user
+  # asked for a specific cell in ip:port form.
+  defp make_static_cell(cspec) do
+  %{ "remote": %{ location: "http://#{cspec}/#{services_loc}", name: cspec }}
+  end
 
   def discovered(spec) do
-		cells = SsdpClient.discover |> spec(spec)
+  cells = SsdpClient.discover |> spec(spec)
     n = Enum.count(cells)
     case spec do
       nil ->

--- a/lib/inet.ex
+++ b/lib/inet.ex
@@ -1,6 +1,8 @@
-
 defmodule Inet do
-  
-  def ntoa(ip), do: :inet_parse.ntoa(ip) |> :erlang.list_to_binary
 
+  def ntoa(ip) do
+    ip
+    |> :inet_parse.ntoa()
+    |> :erlang.list_to_binary()
+  end
 end

--- a/lib/jrtp.ex
+++ b/lib/jrtp.ex
@@ -1,7 +1,7 @@
 defmodule Jrtp do
 
   require Logger
-  
+
   @moduledoc """
   Simple decoder of services document provided by cell
   """
@@ -10,17 +10,17 @@ defmodule Jrtp do
   def get_services(cell) do
     # Logger.info "#{inspect cell}"
     case cell[:location] do
-      nil -> 
+      nil ->
         { :error, :no_location }
-      location -> 
-    		full_url = Path.join(location, "services")
+      location ->
+        full_url = Path.join(location, "services")
         resp = HTTPotion.get full_url
-    		case resp.status_code do
-    			200 -> 
+        case resp.status_code do
+          200 ->
             JSX.decode resp.body, [{:labels, :atom}]
-    			x ->
-            raise "Services request for #{full_url} failed with error #{x}"
-    		end
+          x ->
+            raise "services request for #{full_url} failed with error #{x}"
+        end
     end
   end
 end

--- a/lib/ssdp_client.ex
+++ b/lib/ssdp_client.ex
@@ -3,7 +3,7 @@ defmodule SsdpClient do
   Simple SSDP client used for discovery of cells
   """
   require Logger
-  
+
   @discover_gather_time   2000    # wait up to 2 seconds for responses
 
   @default_ssdp_st "urn:nerves-io:service:cell:1"
@@ -31,15 +31,18 @@ defmodule SsdpClient do
 
   defp merge_gathered(gathered, host, packet) do
     resp = decode_ssdp_packet(packet)
-		{usn, resp} = Dict.pop resp, :usn
+    {usn, resp} = Dict.pop resp, :usn
     {_,_,_,l} = host
-		resp = Dict.merge resp, %{ip: host, name: ".#{l}"}
+    resp = Dict.merge resp, %{ip: host, name: ".#{l}"}
     Dict.put gathered, usn, resp
   end
 
   # returns keys/values given an ssdp packet
   defp decode_ssdp_packet(packet) do
-    {[_raw_http_line], raw_params} = String.split(packet, ["\r\n", "\n"]) |> Enum.split(1)
+    {[_raw_http_line], raw_params} =
+      packet
+      |> String.split(["\r\n", "\n"])
+      |> Enum.split(1)
     #http_line = String.downcase(raw_http_line) |> String.strip
     #{[http_verb, {full_uri], _rest} = String.split(http_line) |> Enum.split(2)
     mapped_params = Enum.map raw_params, fn(x) ->

--- a/mix.exs
+++ b/mix.exs
@@ -15,15 +15,15 @@ defmodule CellTool.Mixfile do
   ]
 
   defp deps, do: [
-		{:exjsx, "~> 3.2.0" },
+    {:exjsx, "~> 3.2.0" },
     {:ibrowse, github: "cmullaparthi/ibrowse", ref: "5ee4a80"},
     #{:ibrowse, github: "cmullaparthi/ibrowse"},
-#		{:httpotion, "~> 0.2.4"},
+    #{:httpotion, "~> 0.2.4"},
     {:httpotion, "~> 2.1"},
     {:conform, "~> 0.17"},
     {:earmark, "~> 0.1", only: :dev},
     {:ex_doc, "~> 0.8", only: :dev}
-	]
+  ]
 
   defp version do
     case File.read("VERSION") do


### PR DESCRIPTION
- Avoid hard tab indentation, use space instead
- Avoid trailing blank lines at the end of the file
- Promote the usage of the ~s instead of string literals
- Avoid unused variables
